### PR TITLE
fix(assert-function): uninvert timeout id check

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -55,7 +55,7 @@ class Expect<T> {
                 }
             } else {
                 this.unregisterEvent(this.retry);
-                if(!this.timeoutId){
+                if(this.timeoutId){
                     clearTimeout(this.timeoutId);
                     this.timeoutId = null;
                 }


### PR DESCRIPTION
This is a very old mistake and it causes the timeout to never be cancelled and it fails even after passing the test